### PR TITLE
Include folder name is case sensitive on Linux

### DIFF
--- a/ads2svd.py
+++ b/ads2svd.py
@@ -57,7 +57,7 @@ def loadxml(p):
     out_file = os.path.join(config["out_dir"] , p.split(os.path.sep)[-1])
     out_file = open(out_file,"w")
     nfail = 0;  
-    incls = [i for i in root.xpath("//xi:include", namespaces={'xi':'http://www.w3.org/2001/XInclude'})]
+    incls = [i for i in root.xpath("//xi:Include", namespaces={'xi':'http://www.w3.org/2001/XInclude'})]
     for el in incls:        
         tree =  etree.ElementTree(el)
         try :


### PR DESCRIPTION
Found an issue with case sensitivity on the include folder.  I suspect this will address https://github.com/Jegeva/ads2svd/issues/1

Without this change I see:
```
joel@hammer:~/git/ads2svd$ ./ads2svd.py -c /opt/arm/developmentstudio-2020.0/sw/debugger/configdb -a
/opt/arm/developmentstudio-2020.0/sw/debugger/configdb/Cores/88FR101.xml
/opt/arm/developmentstudio-2020.0/sw/debugger/configdb/Cores/88FR111.xml
/opt/arm/developmentstudio-2020.0/sw/debugger/configdb/Cores/A12_A7_bigLITTLE.xml
/opt/arm/developmentstudio-2020.0/sw/debugger/configdb/Cores/A15_A7_bigLITTLE.xml
/opt/arm/developmentstudio-2020.0/sw/debugger/configdb/Cores/A17_A7_bigLITTLE.xml
/opt/arm/developmentstudio-2020.0/sw/debugger/configdb/Cores/A53_A35_bigLITTLE.xml
Traceback (most recent call last):
  File "./ads2svd.py", line 64, in loadxml
    tree.xinclude()
  File "src/lxml/etree.pyx", line 2366, in lxml.etree._ElementTree.xinclude
  File "src/lxml/xinclude.pxi", line 62, in lxml.etree.XInclude.__call__
lxml.etree.XIncludeError: XPointer evaluation failed: #xmlns(namespace=http://com.arm.targetconfigurationeditor)xpointer(//namespace:enumeration), line 17

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./ads2svd.py", line 115, in <module>
    get_all()
  File "./ads2svd.py", line 94, in get_all
    loadxml(x)     
  File "./ads2svd.py", line 68, in loadxml
    error_log.write( 'ERR;num=%d;file="%s";errhref="%s";errreason="%s";merrmsg="%s"\n' % (nfail,p[len(config["base_path"]):],el.get("href"),el.get("xpointer"),err))
KeyError: 'base_path'
```

Thanks for the tool :)